### PR TITLE
Update peerDep range of react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "name": "react-native-json-tree",
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0",
-    "react-native": "^0.32.0"
+    "react-native": ">=0.32.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hello

The current peer dep range of react-native doesn't cover the latest version of react-native. This PR changes the range from `^0.32.0` to `>=0.32.0`.

![2016-11-15 13 54 53](https://cloud.githubusercontent.com/assets/613956/20293622/2446a5da-ab3b-11e6-8a49-d86582f84b2e.png)

http://jubianchi.github.io/semver-check/