### PR TITLE
[dist] depend on react-base16-styling@^0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "contributors": [],
   "dependencies": {
-    "react-base16-styling": "github:dean177/react-base16-styling"
+    "react-base16-styling": "^0.5.3"
   },
   "description": "React Native JSON Viewer Component, based on react-json-tree",
   "devDependencies": {


### PR DESCRIPTION
Don't use Github dependencies. It should expose a build `lib` for the published npm module now, see https://github.com/alexkuz/react-base16-styling/blob/master/package.json#L15