### PR TITLE
Improve peerDeps notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
   "main": "src/index.js",
   "name": "react-native-json-tree",
   "peerDependencies": {
-    "react": "^16.0.0-alpha.6",
-    "react-native": "^0.43.2"
+    "react": ">=16.0.0-alpha.6",
+    "react-native": ">=0.43.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This should fix the warning prompted when installing this dependency in more modern react-native projects.
