### PR TITLE
Switch to using the prop-types package for PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "Swaagie"
   ],
   "dependencies": {
+    "prop-types": "^15.6.0",
     "react-base16-styling": "github:dean177/react-base16-styling#fbc6593"
   },
   "description": "React Native JSON viewing component, based on react-json-tree",

--- a/src/ItemRange.js
+++ b/src/ItemRange.js
@@ -1,4 +1,5 @@
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { Text, View } from 'react-native';
 import JSONArrow from './JSONArrow';
 

--- a/src/JSONArrayNode.js
+++ b/src/JSONArrayNode.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import JSONNestedNode from './JSONNestedNode';
 
 // Returns the "n Items" string for this node,

--- a/src/JSONArrow.js
+++ b/src/JSONArrow.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Text, TouchableOpacity, View } from 'react-native';
 
 const JSONArrow = ({ arrowStyle, expanded, nodeType, onPress, styling }) => (

--- a/src/JSONNestedNode.js
+++ b/src/JSONNestedNode.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Text, View } from 'react-native';
 import JSONArrow from './JSONArrow';
 import getCollectionEntries from './getCollectionEntries';

--- a/src/JSONNode.js
+++ b/src/JSONNode.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import objType from './objType';
 import JSONObjectNode from './JSONObjectNode';
 import JSONArrayNode from './JSONArrayNode';

--- a/src/JSONObjectNode.js
+++ b/src/JSONObjectNode.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import JSONNestedNode from './JSONNestedNode';
 
 // Returns the "n Items" string for this node,

--- a/src/JSONValueNode.js
+++ b/src/JSONValueNode.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Text, View } from 'react-native';
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Text, View } from 'react-native';
 import JSONNode from './JSONNode';
 import createStylingFromTheme from './createStylingFromTheme';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4174,6 +4174,14 @@ prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.8:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"


### PR DESCRIPTION
At react 15.5 PropTypes was moved into its own package. This PR switches over to using that package.