### PR TITLE
Remove JSONValueNode defaultProps.

### DIFF
--- a/src/Nodes.js
+++ b/src/Nodes.js
@@ -39,7 +39,7 @@ const JSONValueNode = ({
   keyPath,
   valueRenderer,
   value,
-  valueGetter,
+  valueGetter = (value) => value,
 }) => (
   <View {...styling('value', nodeType, keyPath)}>
     <Text {...styling(['label', 'valueLabel'], nodeType, keyPath)}>
@@ -62,8 +62,6 @@ JSONValueNode.propTypes = {
   valueGetter: PropTypes.func,
   valueRenderer: PropTypes.func.isRequired,
 }
-
-JSONValueNode.defaultProps = { valueGetter: (value) => value }
 
 
 export const JSONNode = ({


### PR DESCRIPTION
#160 & #164 identified several warnings/errors due to props issues, most of which were resolved in #161 & #162. However `JSONValueNode`'s `defaultProps` was not included in either of the fixes.

These changes move the default values from `defaultProps` to the parameters.

I'm not sure how to really test these changes, but they haven't caused any issues in our app.

Shout out to @trajano who identified this issue in both threads, and supplied a [patch](https://github.com/trajano/expo-experiments/blob/expo-52-try-3/patches/react-native-json-tree%2B1.3.0.patch) with the fix.